### PR TITLE
sepolicy: private: Address denial for untrusted_app

### DIFF
--- a/common/private/untrusted_app.te
+++ b/common/private/untrusted_app.te
@@ -1,2 +1,3 @@
+allow untrusted_app_all hal_perf_hwservice:hwservice_manager find;
 allow untrusted_app_all lineage_profile_service:service_manager find;
 allow untrusted_app_all lineage_weather_service:service_manager find;


### PR DESCRIPTION
avc:  denied  { find } for interface=vendor.qti.hardware.perf::IPerf sid=u:r:untrusted_app:s0:c202,c257,c512,c768 pid=9205 scontext=u:r:untrusted_app:s0:c202,c257,c512,c768 tcontext=u:object_r:hal_perf_hwservice:s0 tclass=hwservice_manager permissive=0

Signed-off-by: AnierinB <anierin.t.bliss@gmail.com>